### PR TITLE
Add Kafka and zookeeper

### DIFF
--- a/kafka_zookeeper/kafka-configmap.yaml
+++ b/kafka_zookeeper/kafka-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-config
+data:
+  KAFKA_URL: "kafka-0.kafka.marketplace.svc.cluster.local:9092"

--- a/kafka_zookeeper/kafka-statefulset.yaml
+++ b/kafka_zookeeper/kafka-statefulset.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+spec:
+  ports:
+    - port: 9092
+      name: kafka-port
+    - port: 9093
+      name: ex-kafka-port
+  clusterIP: None  # Headless service
+  selector:
+    app: kafka
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+  labels:
+    app: kafka
+spec:
+  serviceName: "kafka"
+  replicas: 1 
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: wurstmeister/kafka:2.13-2.8.1
+          ports:
+            - containerPort: 9092  # Kafka broker port for internal communication
+            - containerPort: 9093  # External port for client communication
+          env:
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: zookeeper:2181  # ZooKeeper connection string
+            # - name: KAFKA_LISTENERS
+            #   value: PLAINTEXT://0.0.0.0:9092
+            - name: KAFKA_LISTENERS
+              value: INSIDE://0.0.0.0:9092,PLAINTEXT://0.0.0.0:9093  # Internal and external listeners
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: INSIDE:PLAINTEXT,PLAINTEXT:PLAINTEXT  # Define security protocols for each listener
+            - name: KAFKA_LISTENER_NAMES
+              value: INSIDE,PLAINTEXT
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "INSIDE://$(POD_NAME).kafka.marketplace.svc.cluster.local:9092,PLAINTEXT://$(POD_NAME).kafka.marketplace.svc.cluster.local:9093"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/kafka/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: kafka-pvc  # Persistent Volume Claim for Kafka data storage
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kafka-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kafka-pv
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard  # Adjust based on your environment's storage class
+  hostPath:
+    path: /data/kafka  # Local path for storing Kafka data (change this for your environment)

--- a/kafka_zookeeper/zookeeper.yaml
+++ b/kafka_zookeeper/zookeeper.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+  labels:
+    app: zookeeper
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+        - name: zookeeper
+          image: arm64v8/zookeeper:3.7.2
+          ports:
+            - containerPort: 2181
+          env:
+            - name: ZOOKEEPER_SERVER_ID
+              value: "1"  #
+            - name: ZOOKEEPER_ADMINSERVERPORT
+              value: "8080" 
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: datalog
+              mountPath: /datalog
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: zookeeper-pvc-data
+        - name: datalog
+          persistentVolumeClaim:
+            claimName: zookeeper-pvc-datalog
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zookeeper-pvc-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zookeeper-pvc-datalog
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  labels:
+    app: zookeeper
+spec:
+  ports:
+    - port: 2181
+      targetPort: 2181
+      name: client
+  selector:
+    app: zookeeper

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -8,6 +8,11 @@ resources:
   - namespace.yaml
   - ingress.yaml
 
+  # Kafka / zookeeper resources
+  - kafka_zookeeper/zookeeper.yaml
+  - kafka_zookeeper/kafka-statefulset.yaml
+  - kafka_zookeeper/kafka-configmap.yaml
+
   # Microservice-specific resources (Order)
   - ms_order/order_app.yaml
   - ms_order/postgres.yaml

--- a/ms_delivery/delivery_app.yaml
+++ b/ms_delivery/delivery_app.yaml
@@ -17,18 +17,23 @@ spec:
     spec:
       containers:
         - name: ms-delivery
-          image: svysk/ms-delivery:0.1.0
+          image: svysk/ms-delivery:0.2.0
           ports:
             - name: http-delivery
               containerPort: 8081
           resources:
             requests:
-              memory: "128Mi"     # Minimum memory guaranteed
+              memory: "256Mi"     # Minimum memory guaranteed
               cpu: "100m"         # Minimum CPU guaranteed (100m = 0.1 CPU)
             limits:
-              memory: "256Mi"     # Maximum memory allowed
+              memory: "512Mi"     # Maximum memory allowed
               cpu: "500m"         # Maximum CPU allowed (500m = 0.5 CPU)
           env:
+            - name: KAFKA_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: kafka-config
+                  key: KAFKA_URL
             - name: POSTGRES_URL
               valueFrom:
                 configMapKeyRef:

--- a/ms_order/order_app.yaml
+++ b/ms_order/order_app.yaml
@@ -17,16 +17,16 @@ spec:
     spec:
       containers:
         - name: ms-order
-          image: svysk/ms-order:0.1.0
+          image: svysk/ms-order:0.2.0
           ports:
             - name: http-order
               containerPort: 8080
           resources:
             requests:
-              memory: "128Mi"     # Minimum memory guaranteed
+              memory: "256Mi"     # Minimum memory guaranteed
               cpu: "100m"         # Minimum CPU guaranteed (100m = 0.1 CPU)
             limits:
-              memory: "256Mi"     # Maximum memory allowed
+              memory: "512Mi"     # Maximum memory allowed
               cpu: "500m"         # Maximum CPU allowed (500m = 0.5 CPU)
           env:
           - name: DELIVERY_URL
@@ -34,6 +34,11 @@ spec:
               configMapKeyRef:
                 name: order-configmap
                 key: DELIVERY_URL
+          - name: KAFKA_URL
+            valueFrom:
+              configMapKeyRef:
+                name: kafka-config
+                key: KAFKA_URL
           - name: POSTGRES_URL
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
**Summary**
This PR adds **Kafka** and **ZooKeeper** configurations to our **Kubernetes setup**, enabling message-driven communication within microservices architecture.

**Changes Introduced**

**- Kafka Deployment & Service:**

  - Added StatefulSet for Kafka broker.
  - Configured a Service.

**- ZooKeeper Deployment & Service:**

  - Added Deployment for ZooKeeper.
  - Created a Service for Kafka to connect to ZooKeeper.
  
**- Configuration Updates:**

  - Added environment variables for Kafka and ZooKeeper.
  - Configured storage and persistent volumes.
  - Created configMap for Kafka url.

**How to Test:**
``` 
kubectl apply -k . 
```

